### PR TITLE
Validating Site UUID

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -42,6 +42,12 @@ ___TEMPLATE_PARAMETERS___
     "valueValidators": [
       {
         "type": "NON_EMPTY"
+      },
+      {
+        "type": "REGEX",
+        "args": [
+          "^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$"
+        ]
       }
     ],
     "displayName": "Site ID",


### PR DESCRIPTION
This change makes GTM perform an extra validation so that only valid UUID v4 are accepted as Site IDs.